### PR TITLE
Osx fixes

### DIFF
--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -177,8 +177,10 @@ void *ucm_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t off
 {
     ucm_event_t event;
 
-    ucm_trace("ucm_mmap(addr=%p length=%lu prot=0x%x flags=0x%x fd=%d offset=%ld)",
-              addr, length, prot, flags, fd, offset);
+    /* Actual type definition of off_t depends on platform: long on Linux, 
+       long long on OSX */
+    ucm_trace("ucm_mmap(addr=%p length=%lu prot=0x%x flags=0x%x fd=%d offset=%lld)",
+              addr, length, prot, flags, fd, (long long)offset);
 
     ucm_event_enter();
 

--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -10,7 +10,12 @@
 
 #include "malloc_hook.h"
 
-#include <malloc.h>
+#ifdef __APPLE__
+#  include <stdlib.h>
+#else
+#  include <malloc.h>
+#endif
+
 #undef M_TRIM_THRESHOLD
 #undef M_MMAP_THRESHOLD
 #include "allocator.h" /* have to be included after malloc.h */


### PR DESCRIPTION
Two fixes on compile on OSX:
 * Avoid including <malloc.h>
 * Fix printf format string error related to `off_t`, which is `long` on Linux but `long long` on OSX.